### PR TITLE
Add UI and basic reaction logic

### DIFF
--- a/Source/UAIAgent/Private/ReactionSimulatorWidget.cpp
+++ b/Source/UAIAgent/Private/ReactionSimulatorWidget.cpp
@@ -1,0 +1,87 @@
+#include "ReactionSimulatorWidget.h"
+
+#include "Components/ComboBoxString.h"
+#include "Components/Slider.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "ReactionTypes.h"
+
+void UReactionSimulatorWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    if (ExecuteButton)
+    {
+        ExecuteButton->OnClicked.AddDynamic(this, &UReactionSimulatorWidget::OnExecuteClicked);
+    }
+}
+
+void UReactionSimulatorWidget::OnExecuteClicked()
+{
+    const FString NpcName = NPCSelector ? NPCSelector->GetSelectedOption() : FString();
+    const FString SituationStr = SituationSelector ? SituationSelector->GetSelectedOption() : FString();
+
+    ESituationCode Situation = ESituationCode::S1;
+    if (SituationStr == TEXT("S2")) Situation = ESituationCode::S2;
+    else if (SituationStr == TEXT("S3")) Situation = ESituationCode::S3;
+    else if (SituationStr == TEXT("S4")) Situation = ESituationCode::S4;
+    else if (SituationStr == TEXT("S5")) Situation = ESituationCode::S5;
+    else if (SituationStr == TEXT("S6")) Situation = ESituationCode::S6;
+
+    FEmotionVector Vector;
+    if (JoySlider) Vector.Joy = JoySlider->GetValue();
+    if (AngerSlider) Vector.Anger = AngerSlider->GetValue();
+    if (SadnessSlider) Vector.Sadness = SadnessSlider->GetValue();
+    if (SurpriseSlider) Vector.Surprise = SurpriseSlider->GetValue();
+    if (FearSlider) Vector.Fear = FearSlider->GetValue();
+    if (DisgustSlider) Vector.Disgust = DisgustSlider->GetValue();
+
+    const FString Hash = BuildInputHash(NpcName, Situation, Vector);
+
+    FReactionOutput Output = QueryLocalDb(Hash);
+    if (Output.ReactionDescription.IsEmpty())
+    {
+        // Stub LLM response
+        Output.ReactionDescription = TEXT("반응 없음");
+        Output.Dialogue = TEXT("...");
+        CacheLocal(Hash, Output);
+    }
+
+    if (ReactionDescriptionText)
+    {
+        ReactionDescriptionText->SetText(FText::FromString(Output.ReactionDescription));
+    }
+
+    if (DialogueBox)
+    {
+        UTextBlock* NewLine = NewObject<UTextBlock>(this);
+        if (NewLine)
+        {
+            NewLine->SetText(FText::FromString(Output.Dialogue));
+            DialogueBox->AddChildToVerticalBox(NewLine);
+        }
+    }
+}
+
+FString UReactionSimulatorWidget::BuildInputHash(const FString& NpcName, ESituationCode Situation, const FEmotionVector& Vector) const
+{
+    return FString::Printf(TEXT("%s_%d_%.2f_%.2f_%.2f_%.2f_%.2f_%.2f"), *NpcName, (int32)Situation,
+        Vector.Joy, Vector.Anger, Vector.Sadness, Vector.Surprise, Vector.Fear, Vector.Disgust);
+}
+
+FReactionOutput UReactionSimulatorWidget::QueryLocalDb(const FString& Hash) const
+{
+    if (const FReactionOutput* Found = LocalDb.Find(Hash))
+    {
+        return *Found;
+    }
+    return FReactionOutput();
+}
+
+void UReactionSimulatorWidget::CacheLocal(const FString& Hash, const FReactionOutput& Output)
+{
+    LocalDb.Add(Hash, Output);
+}
+

--- a/Source/UAIAgent/Public/ReactionSimulatorWidget.h
+++ b/Source/UAIAgent/Public/ReactionSimulatorWidget.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "ReactionTypes.h"
+#include "ReactionSimulatorWidget.generated.h"
+
+class UComboBoxString;
+class USlider;
+class UButton;
+class UTextBlock;
+class UVerticalBox;
+
+/**\n * UI widget for NPC reaction simulation.\n */
+UCLASS()
+class UAIAGENT_API UReactionSimulatorWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    virtual void NativeConstruct() override;
+
+protected:
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UComboBoxString> NPCSelector;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UComboBoxString> SituationSelector;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> JoySlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> AngerSlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> SadnessSlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> SurpriseSlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> FearSlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<USlider> DisgustSlider;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UButton> ExecuteButton;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UTextBlock> PersonaSummaryText;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UTextBlock> ReactionDescriptionText;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UVerticalBox> DialogueBox;
+
+private:
+    UFUNCTION()
+    void OnExecuteClicked();
+
+    FString BuildInputHash(const FString& NpcName, ESituationCode Situation, const FEmotionVector& Vector) const;
+
+    FReactionOutput QueryLocalDb(const FString& Hash) const;
+
+    void CacheLocal(const FString& Hash, const FReactionOutput& Output);
+
+    TMap<FString, FReactionOutput> LocalDb;
+};
+

--- a/Source/UAIAgent/Public/ReactionTypes.h
+++ b/Source/UAIAgent/Public/ReactionTypes.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ReactionTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class ESituationCode : uint8
+{
+    S1 UMETA(DisplayName = "S1"),
+    S2 UMETA(DisplayName = "S2"),
+    S3 UMETA(DisplayName = "S3"),
+    S4 UMETA(DisplayName = "S4"),
+    S5 UMETA(DisplayName = "S5"),
+    S6 UMETA(DisplayName = "S6")
+};
+
+USTRUCT(BlueprintType)
+struct FEmotionVector
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Joy = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Anger = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Sadness = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Surprise = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Fear = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Disgust = 0.f;
+};
+
+
+USTRUCT(BlueprintType)
+struct FReactionOutput
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FString ReactionDescription;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FString Dialogue;
+};
+


### PR DESCRIPTION
## Summary
- add UReactionSimulatorWidget as UI entry for setting up NPC reactions
- define structs for emotion vectors and reaction output
- implement placeholder reaction generation with local caching

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880eb1e04b88330b4c8225a2d1339d8