### PR TITLE
Add data asset based simulator

### DIFF
--- a/Source/UAIAgent/Presets/MafiaTestPreset.cpp
+++ b/Source/UAIAgent/Presets/MafiaTestPreset.cpp
@@ -1,0 +1,48 @@
+#include "MafiaTestPreset.h"
+
+void UMafiaTestPreset::TestFirstDayIntroduction(AMafiaNPC* NPC)
+{
+    if (!NPC) return;
+    NPC->CurrentEmotion = EEmotionType::Neutral;
+    const FString SituationTag = TEXT("Introduction");
+    NPC->HandleSituation(SituationTag, nullptr);
+}
+
+void UMafiaTestPreset::TestAccusedDefense(AMafiaNPC* NPC, AINPC* Accuser)
+{
+    if (!NPC || !Accuser) return;
+    const FString SituationTag = TEXT("Accusation");
+    NPC->RelationshipMap.FindOrAdd(Accuser);
+    NPC->HandleSituation(SituationTag, Accuser);
+}
+
+void UMafiaTestPreset::TestMafiaSignal(AMafiaNPC* MafiaNPC, AINPC* Ally)
+{
+    if (!MafiaNPC || !Ally) return;
+    FRelationshipData& Rel = MafiaNPC->RelationshipMap.FindOrAdd(Ally);
+    Rel.Trust = 0.8f;
+    Rel.Affinity = 0.5f;
+    MafiaNPC->PerformBluff(Ally);
+}
+
+void UMafiaTestPreset::TestInnocentRage(AMafiaNPC* VillagerNPC, AINPC* Accuser)
+{
+    if (!VillagerNPC || !Accuser) return;
+    VillagerNPC->MyRole = TEXT("Villager");
+    VillagerNPC->CurrentEmotion = EEmotionType::Angry;
+    const FString SituationTag = TEXT("Accusation");
+    VillagerNPC->HandleSituation(SituationTag, Accuser);
+}
+
+void UMafiaTestPreset::TestFinalPlea(AMafiaNPC* NPC)
+{
+    if (!NPC) return;
+    NPC->CurrentEmotion = EEmotionType::Fear;
+    FString Prompt = FString::Printf(TEXT(
+        "You are an NPC facing elimination in a social deduction game. Your role is '%s'. "
+        "You are terrified and plead with the other players to spare you. "
+        "Generate a heartfelt final statement that may sway the vote."
+    ), *NPC->MyRole);
+    const FString Plea = NPC->TriggerLLMDialogue(Prompt);
+    UE_LOG(LogTemp, Log, TEXT("Final plea from %s: %s"), *NPC->NPCName, *Plea);
+}

--- a/Source/UAIAgent/Presets/MafiaTestPreset.h
+++ b/Source/UAIAgent/Presets/MafiaTestPreset.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "AMafiaNPC.h"
+#include "MafiaTestPreset.generated.h"
+
+UCLASS()
+class UMafiaTestPreset : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    UFUNCTION(CallInEditor, BlueprintCallable, Category="Mafia|Test")
+    static void TestFirstDayIntroduction(AMafiaNPC* NPC);
+    UFUNCTION(CallInEditor, BlueprintCallable, Category="Mafia|Test")
+    static void TestAccusedDefense(AMafiaNPC* NPC, AINPC* Accuser);
+    UFUNCTION(CallInEditor, BlueprintCallable, Category="Mafia|Test")
+    static void TestMafiaSignal(AMafiaNPC* MafiaNPC, AINPC* Ally);
+    UFUNCTION(CallInEditor, BlueprintCallable, Category="Mafia|Test")
+    static void TestInnocentRage(AMafiaNPC* VillagerNPC, AINPC* Accuser);
+    UFUNCTION(CallInEditor, BlueprintCallable, Category="Mafia|Test")
+    static void TestFinalPlea(AMafiaNPC* NPC);
+};

--- a/Source/UAIAgent/Private/AINPC.cpp
+++ b/Source/UAIAgent/Private/AINPC.cpp
@@ -1,0 +1,93 @@
+#include "AINPC.h"
+#include "Engine/World.h"
+#include "Kismet/KismetSystemLibrary.h"
+
+AINPC::AINPC()
+{
+    PrimaryActorTick.bCanEverTick = false;
+}
+
+void AINPC::HandleSituation(const FString& SituationTag, AINPC* SourceNPC)
+{
+    UpdateInternalState(SituationTag, SourceNPC);
+    EReactionType ChosenReaction = DecideReaction(SituationTag, SourceNPC);
+    ExecuteReaction(ChosenReaction, SourceNPC);
+}
+
+void AINPC::UpdateInternalState(const FString& SituationTag, AINPC* SourceNPC)
+{
+    if (SourceNPC)
+    {
+        FRelationshipData* Relationship = RelationshipMap.Find(SourceNPC);
+        if (!Relationship)
+        {
+            Relationship = &RelationshipMap.Add(SourceNPC);
+        }
+        if (SituationTag.Equals(TEXT("Accusation"), ESearchCase::IgnoreCase))
+        {
+            Relationship->Trust = FMath::Clamp(Relationship->Trust - 0.3f, 0.f, 1.f);
+            Relationship->Affinity -= 0.2f;
+        }
+        else if (SituationTag.Equals(TEXT("Introduction"), ESearchCase::IgnoreCase))
+        {
+            Relationship->Trust = FMath::Clamp(Relationship->Trust + 0.1f, 0.f, 1.f);
+            Relationship->Affinity += 0.1f;
+        }
+        Relationship->InteractionHistory.Add(SituationTag);
+    }
+
+    if (SituationTag.Equals(TEXT("Accusation"), ESearchCase::IgnoreCase))
+    {
+        CurrentEmotion = EEmotionType::Angry;
+    }
+    else if (SituationTag.Equals(TEXT("Praise"), ESearchCase::IgnoreCase))
+    {
+        CurrentEmotion = EEmotionType::Happy;
+    }
+    else
+    {
+        CurrentEmotion = EEmotionType::Neutral;
+    }
+}
+
+EReactionType AINPC::DecideReaction(const FString& SituationTag, AINPC* SourceNPC)
+{
+    if (CurrentEmotion == EEmotionType::Angry)
+    {
+        return EReactionType::Defend;
+    }
+    else if (SituationTag.Equals(TEXT("Introduction"), ESearchCase::IgnoreCase))
+    {
+        return EReactionType::Speak;
+    }
+    else if (SituationTag.Equals(TEXT("Accusation"), ESearchCase::IgnoreCase))
+    {
+        return EReactionType::Defend;
+    }
+    return EReactionType::Speak;
+}
+
+void AINPC::ExecuteReaction(EReactionType ReactionType, AINPC* TargetNPC)
+{
+    LastReaction = ReactionType;
+    const FString ReactionString = UEnum::GetValueAsString(ReactionType);
+    const FString TargetName = TargetNPC ? TargetNPC->NPCName : TEXT("None");
+    UE_LOG(LogTemp, Log, TEXT("%s performs reaction %s towards %s"), *NPCName, *ReactionString, *TargetName);
+    if (ReactionType == EReactionType::Speak || ReactionType == EReactionType::Bluff || ReactionType == EReactionType::Defend)
+    {
+        FString Prompt = FString::Printf(TEXT("NPC '%s' with MBTI %s feels %s in situation '%s'. Generate a short line of dialogue."), *NPCName, *MBTIType, *UEnum::GetValueAsString(CurrentEmotion), *TargetName);
+        const FString GeneratedLine = TriggerLLMDialogue(Prompt);
+        UE_LOG(LogTemp, Log, TEXT("Generated dialogue: %s"), *GeneratedLine);
+    }
+}
+
+FString AINPC::TriggerLLMDialogue(const FString& PromptContext)
+{
+    return SendPromptToLLM(PromptContext);
+}
+
+FString AINPC::SendPromptToLLM(const FString& Prompt) const
+{
+    UE_LOG(LogTemp, Log, TEXT("Sending prompt to LLM: %s"), *Prompt);
+    return FString::Printf(TEXT("[LLM Response to: %s]"), *Prompt);
+}

--- a/Source/UAIAgent/Private/AMafiaNPC.cpp
+++ b/Source/UAIAgent/Private/AMafiaNPC.cpp
@@ -1,0 +1,65 @@
+#include "AMafiaNPC.h"
+
+AMafiaNPC::AMafiaNPC()
+{
+    MyRole = TEXT("Villager");
+}
+
+AINPC* AMafiaNPC::PickBluffTarget()
+{
+    if (RelationshipMap.Num() == 0)
+    {
+        return nullptr;
+    }
+    AINPC* BestTarget = nullptr;
+    float BestScore = -1.f;
+    for (const auto& Elem : RelationshipMap)
+    {
+        AINPC* Candidate = Elem.Key.Get();
+        if (!Candidate) continue;
+        const FRelationshipData& Data = Elem.Value;
+        const float Score = Data.Trust * 0.7f + Data.Affinity * 0.3f;
+        if (Score > BestScore)
+        {
+            BestScore = Score;
+            BestTarget = Candidate;
+        }
+    }
+    return BestTarget;
+}
+
+void AMafiaNPC::PerformBluff(AINPC* TargetNPC)
+{
+    if (!TargetNPC)
+    {
+        ExecuteReaction(EReactionType::Speak, nullptr);
+        return;
+    }
+    FString Prompt = FString::Printf(TEXT(
+        "You are an NPC in a social deduction game. Your hidden role is '%s'. "
+        "You want to mislead other players by bluffing. Target player: '%s'. "
+        "Your personality type is %s and your current emotion is %s. "
+        "Generate a short persuasive statement that casts suspicion on the target without revealing your own role."
+        ), *MyRole, *TargetNPC->NPCName, *MBTIType, *UEnum::GetValueAsString(CurrentEmotion));
+    const FString BluffLine = TriggerLLMDialogue(Prompt);
+    LastReaction = EReactionType::Bluff;
+    UE_LOG(LogTemp, Log, TEXT("%s bluffs at %s: %s"), *NPCName, *TargetNPC->NPCName, *BluffLine);
+}
+
+EReactionType AMafiaNPC::DecideReaction(const FString& SituationTag, AINPC* SourceNPC)
+{
+    if (MyRole.Equals(TEXT("Mafia"), ESearchCase::IgnoreCase) && SituationTag.Equals(TEXT("Accusation"), ESearchCase::IgnoreCase))
+    {
+        AINPC* BluffTarget = PickBluffTarget();
+        if (BluffTarget)
+        {
+            PerformBluff(BluffTarget);
+            return EReactionType::Bluff;
+        }
+    }
+    if (SituationTag.Equals(TEXT("Introduction"), ESearchCase::IgnoreCase) && MyRole.Equals(TEXT("Mafia"), ESearchCase::IgnoreCase))
+    {
+        return EReactionType::Speak;
+    }
+    return Super::DecideReaction(SituationTag, SourceNPC);
+}

--- a/Source/UAIAgent/Private/ReactionSimulatorManager.cpp
+++ b/Source/UAIAgent/Private/ReactionSimulatorManager.cpp
@@ -1,0 +1,23 @@
+#include "ReactionSimulatorManager.h"
+
+#include "SimulationScenarioAsset.h"
+
+AReactionSimulatorManager::AReactionSimulatorManager()
+{
+    PrimaryActorTick.bCanEverTick = false;
+}
+
+void AReactionSimulatorManager::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (Scenario)
+    {
+        Scenario->Simulate();
+    }
+    else
+    {
+        UE_LOG(LogTemp, Warning, TEXT("ReactionSimulatorManager has no Scenario asset."));
+    }
+}
+

--- a/Source/UAIAgent/Private/SimulationScenarioAsset.cpp
+++ b/Source/UAIAgent/Private/SimulationScenarioAsset.cpp
@@ -1,0 +1,14 @@
+#include "SimulationScenarioAsset.h"
+
+
+void USimulationScenarioAsset::Simulate() const
+{
+    UE_LOG(LogTemp, Log, TEXT("Simulating NPC %s | Situation %s"), *NPCName,
+        *StaticEnum<ESituationCode>()->GetNameStringByValue((int64)SituationCode));
+
+    UE_LOG(LogTemp, Log, TEXT("Emotion: Joy %.2f Anger %.2f Sadness %.2f Surprise %.2f Fear %.2f Disgust %.2f"),
+        EmotionVector.Joy, EmotionVector.Anger, EmotionVector.Sadness,
+        EmotionVector.Surprise, EmotionVector.Fear, EmotionVector.Disgust);
+    UE_LOG(LogTemp, Log, TEXT("Persona: %s"), *Persona);
+}
+

--- a/Source/UAIAgent/Public/AINPC.h
+++ b/Source/UAIAgent/Public/AINPC.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "NPCEnums.h"
+#include "AINPC.generated.h"
+
+UCLASS(Blueprintable)
+class AINPC : public AActor
+{
+    GENERATED_BODY()
+public:
+    AINPC();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NPC")
+    FString NPCName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NPC")
+    FString MBTIType;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NPC")
+    EEmotionType CurrentEmotion = EEmotionType::Neutral;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "NPC")
+    EReactionType LastReaction = EReactionType::None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NPC")
+    TMap<TWeakObjectPtr<AINPC>, FRelationshipData> RelationshipMap;
+
+    UFUNCTION(BlueprintCallable, Category = "NPC")
+    virtual void HandleSituation(const FString& SituationTag, AINPC* SourceNPC);
+
+    UFUNCTION(BlueprintCallable, Category = "NPC")
+    virtual void UpdateInternalState(const FString& SituationTag, AINPC* SourceNPC);
+
+    UFUNCTION(BlueprintCallable, Category = "NPC")
+    virtual EReactionType DecideReaction(const FString& SituationTag, AINPC* SourceNPC);
+
+    UFUNCTION(BlueprintCallable, Category = "NPC")
+    virtual void ExecuteReaction(EReactionType ReactionType, AINPC* TargetNPC);
+
+    UFUNCTION(BlueprintCallable, Category = "NPC")
+    virtual FString TriggerLLMDialogue(const FString& PromptContext);
+
+protected:
+    FString SendPromptToLLM(const FString& Prompt) const;
+};

--- a/Source/UAIAgent/Public/AMafiaNPC.h
+++ b/Source/UAIAgent/Public/AMafiaNPC.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AINPC.h"
+#include "AMafiaNPC.generated.h"
+
+UCLASS(Blueprintable)
+class AMafiaNPC : public AINPC
+{
+    GENERATED_BODY()
+public:
+    AMafiaNPC();
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mafia")
+    FString MyRole;
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mafia")
+    TMap<TWeakObjectPtr<AINPC>, FString> PredictedRoleMap;
+    UFUNCTION(BlueprintCallable, Category = "Mafia")
+    virtual AINPC* PickBluffTarget();
+    UFUNCTION(BlueprintCallable, Category = "Mafia")
+    virtual void PerformBluff(AINPC* TargetNPC);
+    virtual EReactionType DecideReaction(const FString& SituationTag, AINPC* SourceNPC) override;
+};

--- a/Source/UAIAgent/Public/NPCEnums.h
+++ b/Source/UAIAgent/Public/NPCEnums.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "NPCEnums.generated.h"
+
+UENUM(BlueprintType)
+enum class EEmotionType : uint8
+{
+    Neutral      UMETA(DisplayName = "Neutral"),
+    Happy        UMETA(DisplayName = "Happy"),
+    Sad          UMETA(DisplayName = "Sad"),
+    Angry        UMETA(DisplayName = "Angry"),
+    Fear         UMETA(DisplayName = "Fear"),
+    Surprise     UMETA(DisplayName = "Surprise"),
+    Disgust      UMETA(DisplayName = "Disgust")
+};
+
+UENUM(BlueprintType)
+enum class EReactionType : uint8
+{
+    None        UMETA(DisplayName = "None"),
+    Speak       UMETA(DisplayName = "Speak"),
+    Gesture     UMETA(DisplayName = "Gesture"),
+    Vote        UMETA(DisplayName = "Vote"),
+    Bluff       UMETA(DisplayName = "Bluff"),
+    Accuse      UMETA(DisplayName = "Accuse"),
+    Defend      UMETA(DisplayName = "Defend")
+};
+
+USTRUCT(BlueprintType)
+struct FRelationshipData
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Affinity = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    float Trust = 0.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    TArray<FString> InteractionHistory;
+};
+// ...NPCEnums.h 원본 코드...

--- a/Source/UAIAgent/Public/ReactionSimulatorManager.h
+++ b/Source/UAIAgent/Public/ReactionSimulatorManager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "ReactionSimulatorManager.generated.h"
+
+class USimulationScenarioAsset;
+
+/**
+ * Actor responsible for executing a simulation scenario at game start.
+ */
+UCLASS()
+class UAIAGENT_API AReactionSimulatorManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AReactionSimulatorManager();
+
+protected:
+    virtual void BeginPlay() override;
+
+public:
+    /** Scenario asset to simulate when the game starts */
+    UPROPERTY(EditAnywhere, Category="Simulation")
+    TObjectPtr<USimulationScenarioAsset> Scenario;
+};
+

--- a/Source/UAIAgent/Public/SimulationScenarioAsset.h
+++ b/Source/UAIAgent/Public/SimulationScenarioAsset.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "ReactionTypes.h"
+#include "SimulationScenarioAsset.generated.h"
+
+/**
+ * DataAsset representing a single reaction simulation scenario.
+ */
+UCLASS(BlueprintType)
+class UAIAGENT_API USimulationScenarioAsset : public UDataAsset
+{
+    GENERATED_BODY()
+
+public:
+    /** Name of the NPC */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FString NPCName;
+
+    /** Situation code for this scenario */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    ESituationCode SituationCode = ESituationCode::S1;
+
+    /** Emotion vector values */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FEmotionVector EmotionVector;
+
+    /** Short persona or personality summary */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FString Persona;
+
+    /** Execute simulation for this scenario */
+    UFUNCTION(BlueprintCallable, Category="Simulation")
+    void Simulate() const;
+};
+


### PR DESCRIPTION
## Summary
- add `USimulationScenarioAsset` data asset for describing NPC reactions
- add `AReactionSimulatorManager` actor that executes the asset
- log emotion vector, situation and persona from asset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823544c0d88330adea4f13cad1f666