### PR TITLE
Fix blueprint incompatible map types

### DIFF
--- a/Source/UAIAgent/Private/AMafiaNPC.cpp
+++ b/Source/UAIAgent/Private/AMafiaNPC.cpp
@@ -15,7 +15,7 @@ AINPC* AMafiaNPC::PickBluffTarget()
     float BestScore = -1.f;
     for (const auto& Elem : RelationshipMap)
     {
-        AINPC* Candidate = Elem.Key.Get();
+        AINPC* Candidate = Elem.Key;
         if (!Candidate) continue;
         const FRelationshipData& Data = Elem.Value;
         const float Score = Data.Trust * 0.7f + Data.Affinity * 0.3f;

--- a/Source/UAIAgent/Public/AINPC.h
+++ b/Source/UAIAgent/Public/AINPC.h
@@ -24,8 +24,8 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "NPC")
     EReactionType LastReaction = EReactionType::None;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "NPC")
-    TMap<TWeakObjectPtr<AINPC>, FRelationshipData> RelationshipMap;
+    UPROPERTY(EditAnywhere, Category = "NPC")
+    TMap<AINPC*, FRelationshipData> RelationshipMap;
 
     UFUNCTION(BlueprintCallable, Category = "NPC")
     virtual void HandleSituation(const FString& SituationTag, AINPC* SourceNPC);

--- a/Source/UAIAgent/Public/AMafiaNPC.h
+++ b/Source/UAIAgent/Public/AMafiaNPC.h
@@ -13,7 +13,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mafia")
     FString MyRole;
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mafia")
-    TMap<TWeakObjectPtr<AINPC>, FString> PredictedRoleMap;
+    TMap<AINPC*, FString> PredictedRoleMap;
     UFUNCTION(BlueprintCallable, Category = "Mafia")
     virtual AINPC* PickBluffTarget();
     UFUNCTION(BlueprintCallable, Category = "Mafia")


### PR DESCRIPTION
## Summary
- Remove BlueprintReadWrite specifier from RelationshipMap to avoid blueprint exposure
- Replace PredictedRoleMap keys with AINPC* for blueprint compatibility
- Use raw pointer keys for RelationshipMap and update mafia NPC bluff targeting accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918f822e508330a8cd96945904c811